### PR TITLE
traffic-predictor의 예측 결과 Map의 Key를 TrafficEntity -> trafficId로 변경

### DIFF
--- a/api/src/main/java/com/walking/api/repository/traffic/TrafficDetailRepository.java
+++ b/api/src/main/java/com/walking/api/repository/traffic/TrafficDetailRepository.java
@@ -1,7 +1,6 @@
 package com.walking.api.repository.traffic;
 
 import com.walking.data.entity.traffic.TrafficDetailEntity;
-import com.walking.data.entity.traffic.TrafficEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,14 +23,14 @@ public interface TrafficDetailRepository extends JpaRepository<TrafficDetailEnti
 					"WITH sorted_data AS ( "
 							+ "    SELECT *, ROW_NUMBER() OVER (PARTITION BY traffic_id ORDER BY time_left_reg_dt DESC) AS row_num "
 							+ "    FROM traffic_detail "
-							+ "    WHERE traffic_id IN :traffics "
+							+ "    WHERE traffic_id IN :trafficIds "
 							+ " )"
 							+ " SELECT * "
 							+ " FROM sorted_data "
 							+ " WHERE row_num BETWEEN :start AND :end ",
 			nativeQuery = true)
 	List<TrafficDetailEntity> findRecentlyData(
-			@Param("traffics") List<TrafficEntity> traffics,
+			@Param("trafficIds") List<Long> trafficIds,
 			@Param("start") Integer start,
 			@Param("end") Integer end);
 

--- a/api/src/main/java/com/walking/api/service/TrafficCurrentDetailPredictService.java
+++ b/api/src/main/java/com/walking/api/service/TrafficCurrentDetailPredictService.java
@@ -7,7 +7,6 @@ import com.walking.api.service.dto.request.CurrentDetailRequestDto;
 import com.walking.api.service.dto.response.CurrentDetailResponseDto;
 import com.walking.api.util.OffsetDateTimeCalculator;
 import com.walking.data.entity.traffic.TrafficDetailEntity;
-import com.walking.data.entity.traffic.TrafficEntity;
 import com.walking.data.entity.traffic.constant.TrafficColor;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -35,13 +34,40 @@ public class TrafficCurrentDetailPredictService {
 	 */
 	@Transactional(readOnly = true)
 	public CurrentDetailResponseDto execute(CurrentDetailRequestDto dto) {
-		Map<TrafficEntity, PredictedData> predictedMap = dto.getPredictedCycleMap();
-		Set<TrafficEntity> traffics = predictedMap.keySet();
-		List<Long> trafficIds =
-				traffics.stream().map(TrafficEntity::getId).collect(Collectors.toList());
+		Map<Long, PredictedData> predictedMap = dto.getPredictedCycleMap();
+		Set<Long> trafficIdSet = predictedMap.keySet();
+		List<Long> trafficIds = trafficIdSet.stream().collect(Collectors.toList());
 
 		List<TrafficDetailEntity> mostRecenlyData =
 				trafficDetailRepository.findMostRecenlyData(trafficIds);
+		logging(mostRecenlyData);
+		Map<Long, TrafficDetailEntity> separatedData = separateByTraffic(mostRecenlyData);
+
+		Map<Long, ColorAndTimeLeft> currentDetails = new HashMap<>();
+		OffsetDateTime now = OffsetDateTime.now();
+		for (Long id : trafficIds) {
+			PredictedData predictedData = predictedMap.get(id);
+			if (isUnpredictedData(predictedData)) { // 사이클 예측이 완료되지 않은 데이터
+				continue;
+			}
+
+			TrafficDetailEntity currentTrafficDetailEntity = separatedData.get(id);
+			float differenceInSeconds =
+					OffsetDateTimeCalculator.getDifferenceInSeconds(
+							currentTrafficDetailEntity.getTimeLeftRegDt(), now);
+
+			ColorAndTimeLeft currentColorAndtimeLeft =
+					predictCurrentColorAndTimeLeft(
+							currentTrafficDetailEntity, differenceInSeconds, predictedData);
+
+			currentDetails.put(id, currentColorAndtimeLeft);
+			predictedData.updateCurrentColor(currentColorAndtimeLeft.getTrafficColor());
+			predictedData.updateCurrentTimeLeft(currentColorAndtimeLeft.getTimeLeft());
+		}
+		return CurrentDetailResponseDto.builder().currentDetails(predictedMap).build();
+	}
+
+	private static void logging(List<TrafficDetailEntity> mostRecenlyData) {
 		for (TrafficDetailEntity mostRecenlyDatum : mostRecenlyData) {
 			log.debug(
 					mostRecenlyDatum.getTraffic().getId()
@@ -53,30 +79,6 @@ public class TrafficCurrentDetailPredictService {
 							+ mostRecenlyDatum.getTimeLeftRegDt()
 							+ ")");
 		}
-		Map<TrafficEntity, TrafficDetailEntity> separatedData = separateByTraffic(mostRecenlyData);
-
-		Map<TrafficEntity, ColorAndTimeLeft> currentDetails = new HashMap<>();
-		OffsetDateTime now = OffsetDateTime.now();
-		for (TrafficEntity traffic : traffics) {
-			PredictedData predictedData = predictedMap.get(traffic);
-			if (isUnpredictedData(predictedData)) { // 사이클 예측이 완료되지 않은 데이터
-				continue;
-			}
-
-			TrafficDetailEntity currentTrafficDetailEntity = separatedData.get(traffic);
-			float differenceInSeconds =
-					OffsetDateTimeCalculator.getDifferenceInSeconds(
-							currentTrafficDetailEntity.getTimeLeftRegDt(), now);
-
-			ColorAndTimeLeft currentColorAndtimeLeft =
-					predictCurrentColorAndTimeLeft(
-							traffic, currentTrafficDetailEntity, differenceInSeconds, predictedData);
-
-			currentDetails.put(traffic, currentColorAndtimeLeft);
-			predictedData.updateCurrentColor(currentColorAndtimeLeft.getTrafficColor());
-			predictedData.updateCurrentTimeLeft(currentColorAndtimeLeft.getTimeLeft());
-		}
-		return CurrentDetailResponseDto.builder().currentDetails(predictedMap).build();
 	}
 
 	/**
@@ -92,14 +94,12 @@ public class TrafficCurrentDetailPredictService {
 	/**
 	 * 하나의 신호등에 대하여 현재 신호 색상과 잔여시간을 예측하는 작업을 수행
 	 *
-	 * @param traffic 예측할 신호등
 	 * @param currentTrafficDetailEntity
 	 * @param differenceInSeconds 예측을 해야하는 시간의 크기
 	 * @param predictedData 예측에 필요한 사이클 정보
 	 * @return 현재 신호 색상 및 잔여시간
 	 */
 	private static ColorAndTimeLeft predictCurrentColorAndTimeLeft(
-			TrafficEntity traffic,
 			TrafficDetailEntity currentTrafficDetailEntity,
 			float differenceInSeconds,
 			PredictedData predictedData) {
@@ -111,7 +111,8 @@ public class TrafficCurrentDetailPredictService {
 		// 현재 색상에 대한 잔여시간을 먼저 소진시켜본다.
 		differenceInSeconds = differenceInSeconds - currentTrafficDetailEntity.getTimeLeft();
 
-		log.debug("신호등 [" + traffic.getId() + "]의 현재 시간을 예측 하고 있습니다...");
+		log.debug(
+				"신호등 [" + currentTrafficDetailEntity.getTraffic().getId() + "]의 현재 시간을 예측 하고 있습니다...");
 		while (differenceInSeconds >= 0) {
 			if (currentColor.isRed()) { // 최근 데이터의 색상이 red
 				currentColor = TrafficColor.GREEN;
@@ -129,14 +130,13 @@ public class TrafficCurrentDetailPredictService {
 		return currentColorAndtimeLeft;
 	}
 
-	private Map<TrafficEntity, TrafficDetailEntity> separateByTraffic(
+	private Map<Long, TrafficDetailEntity> separateByTraffic(
 			List<TrafficDetailEntity> mostRecentlyData) {
-		Map<TrafficEntity, TrafficDetailEntity> separatedData = new HashMap<>();
 
-		for (TrafficDetailEntity recentlyDatum : mostRecentlyData) {
-			separatedData.put(recentlyDatum.getTraffic(), recentlyDatum);
-		}
-
-		return separatedData;
+		return mostRecentlyData.stream()
+				.collect(
+						Collectors.toMap(
+								trafficDetailEntity -> trafficDetailEntity.getTraffic().getId(),
+								trafficDetailEntity -> trafficDetailEntity));
 	}
 }

--- a/api/src/main/java/com/walking/api/service/TrafficIntegrationPredictService.java
+++ b/api/src/main/java/com/walking/api/service/TrafficIntegrationPredictService.java
@@ -6,7 +6,6 @@ import com.walking.api.service.dto.request.CyclePredictionRequestDto;
 import com.walking.api.service.dto.request.IntegrationPredictRequestDto;
 import com.walking.api.service.dto.response.CurrentDetailResponseDto;
 import com.walking.api.service.dto.response.IntegrationPredictResponseDto;
-import com.walking.data.entity.traffic.TrafficEntity;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -30,17 +29,17 @@ public class TrafficIntegrationPredictService {
 		List<Long> trafficIds = requestDto.getTrafficIds();
 		CyclePredictionRequestDto cyclePredictionRequestDto =
 				new CyclePredictionRequestDto(trafficIds, dataInterval);
-		Map<TrafficEntity, PredictedData> predictDataMap =
+		Map<Long, PredictedData> predictedCycleMap =
 				trafficCyclePredictService.execute(cyclePredictionRequestDto);
 
 		CurrentDetailRequestDto currentDetailRequestDto =
-				CurrentDetailRequestDto.builder().predictedCycleMap(predictDataMap).build();
-		CurrentDetailResponseDto responseDto =
+				CurrentDetailRequestDto.builder().predictedCycleMap(predictedCycleMap).build();
+		CurrentDetailResponseDto currentDetailResponseDto =
 				trafficCurrentDetailPredictService.execute(currentDetailRequestDto);
 
 		// 사이클 예측값과 현재시간에 대한 예측값을 모아서 리턴하도록
 		return IntegrationPredictResponseDto.builder()
-				.predictedDataMap(responseDto.getCurrentDetails())
+				.predictedDataMap(currentDetailResponseDto.getCurrentDetails())
 				.build();
 	}
 }

--- a/api/src/main/java/com/walking/api/service/dto/request/CurrentDetailRequestDto.java
+++ b/api/src/main/java/com/walking/api/service/dto/request/CurrentDetailRequestDto.java
@@ -1,7 +1,6 @@
 package com.walking.api.service.dto.request;
 
 import com.walking.api.service.dto.PredictedData;
-import com.walking.data.entity.traffic.TrafficEntity;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +9,5 @@ import lombok.Getter;
 @Builder
 public class CurrentDetailRequestDto {
 
-	private Map<TrafficEntity, PredictedData> predictedCycleMap;
+	private Map<Long, PredictedData> predictedCycleMap;
 }

--- a/api/src/main/java/com/walking/api/service/dto/response/CurrentDetailResponseDto.java
+++ b/api/src/main/java/com/walking/api/service/dto/response/CurrentDetailResponseDto.java
@@ -1,7 +1,6 @@
 package com.walking.api.service.dto.response;
 
 import com.walking.api.service.dto.PredictedData;
-import com.walking.data.entity.traffic.TrafficEntity;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +9,5 @@ import lombok.Getter;
 @Builder
 public class CurrentDetailResponseDto {
 
-	Map<TrafficEntity, PredictedData> currentDetails;
+	Map<Long, PredictedData> currentDetails;
 }

--- a/api/src/main/java/com/walking/api/service/dto/response/IntegrationPredictResponseDto.java
+++ b/api/src/main/java/com/walking/api/service/dto/response/IntegrationPredictResponseDto.java
@@ -1,7 +1,6 @@
 package com.walking.api.service.dto.response;
 
 import com.walking.api.service.dto.PredictedData;
-import com.walking.data.entity.traffic.TrafficEntity;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +9,6 @@ import lombok.Getter;
 @Builder
 public class IntegrationPredictResponseDto {
 
-	/** Key: 신호등, Value: 예측된 데이터 */
-	private Map<TrafficEntity, PredictedData> predictedDataMap;
+	/** Key: 신호등 아이디, Value: 예측된 데이터 */
+	private Map<Long, PredictedData> predictedDataMap;
 }

--- a/api/src/test/java/com/walking/api/service/TrafficIntegrationPredictServiceTest.java
+++ b/api/src/test/java/com/walking/api/service/TrafficIntegrationPredictServiceTest.java
@@ -1,0 +1,51 @@
+package com.walking.api.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.walking.api.ApiApp;
+import com.walking.api.service.dto.PredictedData;
+import com.walking.api.service.dto.request.IntegrationPredictRequestDto;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles(value = "test")
+@SpringBootTest(classes = ApiApp.class)
+@Slf4j
+class TrafficIntegrationPredictServiceTest {
+
+	@Autowired TrafficIntegrationPredictService integrationPredictService;
+
+	@ParameterizedTest
+	@MethodSource("getTrafficIds")
+	void example(List<Long> trafficIds) {
+		Map<Long, PredictedData> predictedDataMap =
+				integrationPredictService
+						.execute(IntegrationPredictRequestDto.builder().trafficIds(trafficIds).build())
+						.getPredictedDataMap();
+
+		for (Long trafficId : predictedDataMap.keySet()) {
+			log.debug(trafficId + "의 결과는 " + predictedDataMap.get(trafficId));
+		}
+	}
+
+	static Stream<Arguments> getTrafficIds() {
+		List<Long> trafficIds01 = Arrays.asList(3L, 39L, 4106L, 15L, 16L, 4121L, 43L, 50L, 51L, 52L);
+		List<Long> trafficIds02 =
+				Arrays.asList(139L, 4240L, 4267L, 175L, 176L, 177L, 180L, 182L, 183L, 4279L);
+		List<Long> invalidIds = Arrays.asList(1L, 2L, 4L, 9999L);
+
+		return Stream.of(
+				Arguments.arguments(trafficIds01),
+				Arguments.arguments(trafficIds02),
+				Arguments.arguments(invalidIds));
+	}
+}


### PR DESCRIPTION
중첩된 트랜잭션으로 인하여 각각의 트랜잭션에서 조회한 TrafficEntity가 동일하지 않아 이에 대한 해결을 위해
잔여 시간 계산 및 사이클 예측 결과에서 Map의 Key를 TrafficEntity -> trafficId로 사용하도록 수정