### PR TITLE
hotfix: 누락된 보행자 신호등 상태값 추가

### DIFF
--- a/batch/src/main/java/com/walking/batch/chunk/dto/TrafficApiDetailDto.java
+++ b/batch/src/main/java/com/walking/batch/chunk/dto/TrafficApiDetailDto.java
@@ -73,7 +73,7 @@ public class TrafficApiDetailDto {
 				|| pdsgStatNm.equals("permissive-clearance")) {
 			return "GREEN";
 		}
-		if (pdsgStatNm.equals("dark")) {
+		if (pdsgStatNm.equals("dark") || pdsgStatNm.equals("protected-clearance")) {
 			return "DARK";
 		}
 		throw new IllegalArgumentException(


### PR DESCRIPTION
protected-clearance 는 노란색 신호를 의미하지만 "DARK" 로 처리하였습니다.

- 노란불에 대한 별도의 처리가 프로젝트 마감 기한을 고려하였을 때 중요한 작업은 아니라고 판단하여 꺼진 신호등 처리 하였습니다.
